### PR TITLE
Add compatibility for mate-terminal and gnome-terminal

### DIFF
--- a/vim-anywhere
+++ b/vim-anywhere
@@ -32,7 +32,7 @@ file=$(mktemp)
 if [[ $vim == 'gvim' ]]; then
     $vim "$file"
 else
-    $terminal -e $vim "$file"
+    $terminal -e "$vim $file"
 fi
 
 cat $file | setclip


### PR DESCRIPTION
The `-e` option for mate-terminal and gnome-terminal only executes the next single argument. This means vim doesn't receive the file name to edit.

We could use the `-x` option to execute the remainder of the command line inside the terminal, but this would break compatibility with other terminal emulators.

Instead, let's quote the entire command line. This feeds the vim executable name and file name as one argument to the terminal. The mktemp utility doesn't generate filenames with spaces so it's ok to not
quote the result.

Note: If a mate-terminal or gnome-terminal instance is already running a new terminal will join that session and not block the bash script. The vim-anywhere script will copy the contents of the newly created empty file and exit. For mate-terminal and older versions of gnome-terminal this can be prevented by using the `--disable-factory` option like so:

    $ vim-anywhere vim "mate-terminal --disable-factory"

Newer versions of gnome-terminal drop support for the `--disable-factory` option and require a more advanced method for monitoring when the temporary file has been written and closed. Supporting all terminal emulators is beyond the scope of this commit.